### PR TITLE
remove broken -v option for now

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,10 +8,6 @@ pub struct Cli {
 	#[arg(short, long, value_delimiter(','))]
 	pub options: Vec<String>,
 
-	// TODO: passing multiple '-v's increases log level
-	#[arg(short, long)]
-	pub verbose: bool,
-
 	pub device:     PathBuf,
 	pub mountpoint: PathBuf,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::Parser;
-use log::LevelFilter;
 
 use crate::{cli::Cli, ufs::Ufs};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,6 @@ fn main() -> Result<()> {
 	env_logger::init();
 	let cli = Cli::parse();
 
-	if cli.verbose {
-		log::set_max_level(LevelFilter::Trace);
-	}
-
 	let fs = Ufs::open(&cli.device)?;
 
 	fuser::mount2(fs, &cli.mountpoint, &cli.options())?;


### PR DESCRIPTION
At the moment the `-v` option does nothing. I don't know how to fix this, so let's just remove it for now.