### PR TITLE
Final release as part of GSoC 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fuse-ufs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuse-ufs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 exclude = ["doc/*"]
 license = "BSD-2-Clause"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 
 - ChangeLog ([#62](https://github.com/realchonk/fuse-ufs/pull/62))
 - man page ([#57](https://github.com/realchonk/fuse-ufs/pull/57))
+- `-v` and `-q` flags ([#66](https://github.com/realchonk/fuse-ufs/pull/66))
 
 ### Fixed
 - indirect block addressing ([#63](https://github.com/realchonk/fuse-ufs/pull/63))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,7 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 ### Changed
 
 - README
+- Fix Cargo.toml for publishing
 
 ### [0.2.0] - 2024-08-11
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,10 +24,6 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 
 - indirect block addressing ([#63](https://github.com/realchonk/fuse-ufs/pull/63))
 
-### Removed
-
-- `-v` option ([#58](https://github.com/realchonk/fuse-ufs/pull/58))
-
 ### [0.2.1] - 2024-08-15
 
 ### Changed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,7 +14,7 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 - man page ([#57](https://github.com/realchonk/fuse-ufs/pull/57))
 - `-v` and `-q` flags ([#66](https://github.com/realchonk/fuse-ufs/pull/66))
 - `-f` option ([#68](https://github.com/realchonk/fuse-ufs/pull/68))
-- the ability to mount via `/etc/fstab` ([#69](https://github.com/realchonk/fuse-ufs/pull/69))
+- the ability to mount via `/etc/fstab` on Linux ([#69](https://github.com/realchonk/fuse-ufs/pull/69))
 
 ### Changed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,8 +13,14 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 - ChangeLog ([#62](https://github.com/realchonk/fuse-ufs/pull/62))
 - man page ([#57](https://github.com/realchonk/fuse-ufs/pull/57))
 - `-v` and `-q` flags ([#66](https://github.com/realchonk/fuse-ufs/pull/66))
+- `-f` option ([#68](https://github.com/realchonk/fuse-ufs/pull/68))
+
+### Changed
+
+- fuse-ufs now starts in the background by default ([#68](https://github.com/realchonk/fuse-ufs/pull/68))
 
 ### Fixed
+
 - indirect block addressing ([#63](https://github.com/realchonk/fuse-ufs/pull/63))
 
 ### Removed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 - man page ([#57](https://github.com/realchonk/fuse-ufs/pull/57))
 - `-v` and `-q` flags ([#66](https://github.com/realchonk/fuse-ufs/pull/66))
 - `-f` option ([#68](https://github.com/realchonk/fuse-ufs/pull/68))
+- the ability to mount via `/etc/fstab` ([#69](https://github.com/realchonk/fuse-ufs/pull/69))
 
 ### Changed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,12 +10,12 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 
 ### Added
 
-- ChangeLog (#62)
-- man page (#57)
+- ChangeLog ([#62](https://github.com/realchonk/fuse-ufs/pull/62))
+- man page ([#57](https://github.com/realchonk/fuse-ufs/pull/57))
 
 ### Removed
 
-- `-v` option (#58)
+- `-v` option ([#58](https://github.com/realchonk/fuse-ufs/pull/58))
 
 ### [0.2.1] - 2024-08-15
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,18 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [0.3.0] - 2024-08-22
 
+This was the final release as part of [Google Summer of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/mCAcivuH).
+
 ### Added
 
-- ChangeLog
-- man page
-
-### Changed
-
-- README
+- ChangeLog (#62)
+- man page (#57)
 
 ### Removed
 
-- `-v` option
+- `-v` option (#58)
 
 ### [0.2.1] - 2024-08-15
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+
+## [0.3.0] - 2024-08-22
+
+### Added
+
+- ChangeLog
+- man page
+
+### Changed
+
+- README
+
+### Removed
+
+- `-v` option
+
+### [0.2.1] - 2024-08-15
+
+### Changed
+
+- README
+
+### [0.2.0] - 2024-08-11
+
+This was the first formal release of fuse-ufs.
+
+[0.3.0]: https://github.com/realchonk/fuse-ufs/compare/0.2.1...0.3.0
+[0.2.1]: https://github.com/realchonk/fuse-ufs/compare/0.2.0...0.2.1
+[0.2.0]: https://github.com/realchonk/fuse-ufs/releases/tag/0.2.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ This was the final release as part of [Google Summer of Code 2024](https://summe
 - ChangeLog ([#62](https://github.com/realchonk/fuse-ufs/pull/62))
 - man page ([#57](https://github.com/realchonk/fuse-ufs/pull/57))
 
+### Fixed
+- indirect block addressing ([#63](https://github.com/realchonk/fuse-ufs/pull/63))
+
 ### Removed
 
 - `-v` option ([#58](https://github.com/realchonk/fuse-ufs/pull/58))

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ prepare: fmt lint
 
 fmt:
 	cargo +nightly fmt
+	./scripts/fmt-changelog.sh
 
 lint:
 	cargo clippy --all-targets

--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ $ make
 
 ## Sponsorship
 This project was sponsored as part of [Google Summer of Code 2024](https://summerofcode.withgoogle.com/programs/2024).
+The final release during GSoC was [0.3.0](https://github.com/realchonk/fuse-ufs/releases/tag/0.3.0).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Softupdates
 
 ## Packages
-[![Packaging status](https://repology.org/badge/vertical-allrepos/fusefs:ufs.svg)](https://repology.org/project/fusefs:ufs/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/fuse-ufs.svg)](https://repology.org/project/fuse-ufs/versions)
 
 - [Arch Linux AUR](https://aur.archlinux.org/packages/fuse-ufs)
 - FreeBSD (TODO)

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ $ make
 ```
 
 ## Sponsorship
-This project was sponsored as part of [Google Summer of Code 2024](https://summerofcode.withgoogle.com/programs/2024).
+This project was sponsored as part of [Google Summer of Code 2024]($https://summerofcode.withgoogle.com/programs/2024/projects/mCAcivuH).
 The final release during GSoC was [0.3.0](https://github.com/realchonk/fuse-ufs/releases/tag/0.3.0).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 - Softupdates
 
 ## Packages
+[![Packaging status](https://repology.org/badge/vertical-allrepos/fusefs:ufs.svg)](https://repology.org/project/fusefs:ufs/versions)
+
 - [Arch Linux AUR](https://aur.archlinux.org/packages/fuse-ufs)
 - FreeBSD (TODO)
 - [crates.io](https://crates.io/crates/fuse-ufs)

--- a/docs/fuse-ufs.8
+++ b/docs/fuse-ufs.8
@@ -4,7 +4,7 @@
 .Os
 .Sh NAME
 .Nm fuse-ufs
-.Nd FUSE3 implementation FreeBSD's UFSv2
+.Nd FUSE3 implementation of FreeBSD's UFSv2
 .Sh SYNOPSIS
 .Nm fuse-ufs
 .\" TODO: options

--- a/scripts/fmt-changelog.sh
+++ b/scripts/fmt-changelog.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+sed 's@(#\([0-9]*\))@([#\1](https://github.com/realchonk/fuse-ufs/pull/\1))@'	\
+	< ChangeLog.md > ChangeLog.new
+mv ChangeLog.new ChangeLog.md


### PR DESCRIPTION
This will be the final release of fuse-ufs during GSoC 2024.
Deadline: Saturday

Required: 
- #60
- #63 
- #68
- #69 

Bonus:
- #54
- #56
- #66 