### PR TITLE
Add a `-f` option (foreground)

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 Short Term:
-- `-f` option (foreground)
 - more integration tests
 - more unit tests
 

--- a/docs/fuse-ufs.8
+++ b/docs/fuse-ufs.8
@@ -38,6 +38,8 @@ These options have no effect on the mounted filesystem,
 as there is no write support yet.
 .It Fl o Ar rw
 As write support is not present, this option causes the program to crash.
+.It Fl f
+Wait for the filesystem to be unmounted before exiting.
 .It Fl v
 Increase the logging verbosity (this flag can be specified multiple times).
 .It Fl q

--- a/docs/fuse-ufs.8
+++ b/docs/fuse-ufs.8
@@ -1,5 +1,5 @@
 .\" Copyright (c) 2024 Benjamin Stürz <benni@stuerz.xyz>
-.Dd August 21, 2024
+.Dd August 23, 2024
 .Dt FUSE-UFS 8
 .Os
 .Sh NAME

--- a/docs/fuse-ufs.8
+++ b/docs/fuse-ufs.8
@@ -6,11 +6,13 @@
 .Nm fuse-ufs
 .Nd FUSE3 implementation FreeBSD's UFSv2
 .Sh SYNOPSIS
-.Nm fuse-ufs
-.\" TODO: options
+.Nm
+.Op Fl fqv
 .Op Fl o Ar options
 .Ar special
 .Ar mountpoint
+.Nm
+.Fl -help
 .Sh DESCRIPTION
 .Nm
 allows you to mount a FreeBSD UFSv2 filesystem.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,10 @@ pub struct Cli {
 
 	#[command(flatten)]
 	pub verbose: Verbosity<WarnLevel>,
+
+	/// Wait until the filesystem is unmounted.
+	#[arg(short)]
+	pub foreground: bool,
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,11 @@ fn main() -> Result<()> {
 
 	let fs = Ufs::open(&cli.device)?;
 
-	fuser::mount2(fs, &cli.mountpoint, &cli.options())?;
+	if cli.foreground {
+		fuser::mount2(fs, &cli.mountpoint, &cli.options())?;
+	} else {
+		fuser::spawn_mount2(fs, &cli.mountpoint, &cli.options())?;
+	}
+
 	Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -99,6 +99,7 @@ fn harness(img: &Path) -> Harness {
 	let d = tempdir().unwrap();
 	let child = Command::cargo_bin("fuse-ufs")
 		.unwrap()
+		.arg("-f")
 		.arg(img)
 		.arg(d.path())
 		.spawn()


### PR DESCRIPTION
Make fuse-ufs run in the background by default
and add the option (`-f`) to restore the old behavior.