### PR TITLE
Limit file distributed with the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "fuse-ufs"
 version = "0.2.1"
 edition = "2021"
-exclude = ["doc/*"]
 license = "BSD-2-Clause"
 authors = ["Benjamin Stürz <benni@stuerz.xyz>", "Alan Somers <asomers@gmail.com>"]
 homepage = "https://github.com/realchonk/fuse-ufs"
@@ -10,6 +9,7 @@ description = "FUSE implementation of FreeBSD's UFSv2"
 repository = "https://github.com/realchonk/fuse-ufs"
 rust-version = "1.74.0"
 documentation = "https://docs.rs/fuse-ufs"
+include = ["src/**/*", "LICENSE.md", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Exclude stuff like tests, docs, and test fixtures, to minimize the distributed crate's size.