### PR TITLE
Remove the homepage from the cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 exclude = ["doc/*"]
 license = "BSD-2-Clause"
 authors = ["Benjamin Stürz <benni@stuerz.xyz>", "Alan Somers <asomers@gmail.com>"]
-homepage = "https://github.com/realchonk/fuse-ufs"
 description = "FUSE implementation of FreeBSD's UFSv2"
 repository = "https://github.com/realchonk/fuse-ufs"
 rust-version = "1.74.0"


### PR DESCRIPTION
Official guidelines recommend not listing a home page if it's the same as the repository.
https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field