### PR TITLE
Don't include support for env_logger's regexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.83"
 bincode = "2.0.0-rc.3"
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.1"
-env_logger = "0.11.3"
+env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime"] }
 fuser = "0.14.0"
 libc = "0.2.155"
 log = "0.4.22"


### PR DESCRIPTION
We weren't using them anyway, especially with the new "-v" feature. This reduces the binary size by about half.