### PR TITLE
Implement rudimentary fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +129,17 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -291,6 +308,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "rufs",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +370,17 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -605,6 +650,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["rufs", "fuse-ufs"]
+members = ["rufs", "fuse-ufs", "fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -22,3 +22,6 @@ rstest = { version = "0.19.0", default-features = false }
 rstest_reuse = "0.7.0"
 tempfile = "3.0"
 xattr = "1.3.1"
+
+# Fuzz dependencies
+libfuzzer-sys = "0.4"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ fmt:
 lint:
 	cargo clippy --all-targets
 
+fuz:
+	mkdir -p fuzz/corpus/ufs/
+	unzstd -o fuzz/corpus/ufs/ufs-big.img -kf resources/ufs-big.img.zst
+	unzstd -o fuzz/corpus/ufs/ufs-little.img -kf resources/ufs-little.img.zst
+	# NOTE: Add -j if you want more fuzz jobs
+	cargo +nightly fuzz run ufs
+
 clean:
 	rm -f fuse-ufs-bin
 	cargo clean

--- a/fuse-ufs/src/fs.rs
+++ b/fuse-ufs/src/fs.rs
@@ -1,5 +1,6 @@
 use std::{
 	ffi::{c_int, OsStr},
+	fs::File,
 	io::{Error as IoError, ErrorKind, Result as IoResult},
 	path::Path,
 	time::Duration,
@@ -21,13 +22,15 @@ fn transino(inr: u64) -> IoResult<InodeNum> {
 	if inr == fuser::FUSE_ROOT_ID {
 		Ok(InodeNum::ROOT)
 	} else {
-		let inr = inr.try_into().map_err(|_| IoError::from_raw_os_error(libc::EINVAL))?;
+		let inr = inr
+			.try_into()
+			.map_err(|_| IoError::from_raw_os_error(libc::EINVAL))?;
 		Ok(unsafe { InodeNum::new(inr) })
 	}
 }
 
 pub struct Fs {
-	ufs: Ufs,
+	ufs: Ufs<File>,
 }
 
 impl Fs {

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys.workspace = true
+rufs = { path = "../rufs" }
+
+[[bin]]
+name = "ufs"
+path = "fuzz_targets/ufs.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/ufs.rs
+++ b/fuzz/fuzz_targets/ufs.rs
@@ -1,0 +1,28 @@
+#![no_main]
+
+use std::io::{Cursor, Read, Seek};
+
+use libfuzzer_sys::fuzz_target;
+use rufs::*;
+
+fuzz_target!(|data: &[u8]| {
+	let rdr = BlockReader::new(Cursor::new(data), 4096);
+	let mut fs = match Ufs::new(rdr) {
+		Ok(fs) => fs,
+		// Malformed FS already detected and handled properly by rufs
+		Err(_) => return,
+	};
+	traverse(&mut fs, InodeNum::ROOT);
+});
+
+fn traverse<R: Read + Seek>(fs: &mut Ufs<R>, inr: InodeNum) {
+	let mut children = Vec::new();
+	let _ = fs.dir_iter(inr, |name, inr, kind| {
+		children.push((name.to_owned(), inr, kind));
+		None::<()>
+	});
+	for (_name, cinr, _kind) in children {
+		// TODO: Also excercise other fs methods
+		traverse(fs, cinr);
+	}
+}

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -20,3 +20,6 @@ log.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/rufs/src/data.rs
+++ b/rufs/src/data.rs
@@ -45,6 +45,7 @@ impl InodeNum {
 	pub fn get(&self) -> u32 {
 		self.0
 	}
+
 	pub fn get64(&self) -> u64 {
 		self.0.into()
 	}

--- a/rufs/src/inode.rs
+++ b/rufs/src/inode.rs
@@ -57,21 +57,21 @@ impl Inode {
 
 	pub fn as_fileattr(&self, ino: InodeNum) -> FileAttr {
 		FileAttr {
-			ino: ino.get64(),
-			size: self.size,
-			blocks: self.blocks,
-			atime: self.atime(),
-			mtime: self.mtime(),
-			ctime: self.ctime(),
-			crtime: self.btime(),
-			kind: self.kind(),
-			perm: self.perm(),
-			nlink: self.nlink.into(),
-			uid: self.uid,
-			gid: self.gid,
-			rdev: 0,
+			ino:     ino.get64(),
+			size:    self.size,
+			blocks:  self.blocks,
+			atime:   self.atime(),
+			mtime:   self.mtime(),
+			ctime:   self.ctime(),
+			crtime:  self.btime(),
+			kind:    self.kind(),
+			perm:    self.perm(),
+			nlink:   self.nlink.into(),
+			uid:     self.uid,
+			gid:     self.gid,
+			rdev:    0,
 			blksize: self.blksize,
-			flags: self.flags,
+			flags:   self.flags,
 		}
 	}
 

--- a/rufs/src/lib.rs
+++ b/rufs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(fuzzing, allow(dead_code, unused_imports, unused_mut))]
+
 mod blockreader;
 mod data;
 mod decoder;
@@ -5,7 +7,7 @@ mod inode;
 mod ufs;
 
 pub use crate::{
+	blockreader::BlockReader,
 	data::{Inode, InodeNum},
 	ufs::{Info, Ufs},
 };
-

--- a/rufs/src/ufs/dir.rs
+++ b/rufs/src/ufs/dir.rs
@@ -54,15 +54,18 @@ fn readdir_block<T>(
 	Ok(None)
 }
 
-impl Ufs {
+impl<R: Read + Seek> Ufs<R> {
 	pub fn dir_lookup(&mut self, pinr: InodeNum, name: &OsStr) -> IoResult<InodeNum> {
-		self.dir_iter(pinr, |name2, inr, _kind| {
-			if name == name2 {
-				Some(inr)
-			} else {
-				None
-			}
-		})?
+		self.dir_iter(
+			pinr,
+			|name2, inr, _kind| {
+				if name == name2 {
+					Some(inr)
+				} else {
+					None
+				}
+			},
+		)?
 		.ok_or(err!(ENOENT))
 	}
 

--- a/rufs/src/ufs/symlink.rs
+++ b/rufs/src/ufs/symlink.rs
@@ -1,8 +1,7 @@
+use super::*;
 use crate::InodeNum;
 
-use super::*;
-
-impl Ufs {
+impl<R: Read + Seek> Ufs<R> {
 	pub fn symlink_read(&mut self, inr: InodeNum) -> IoResult<Vec<u8>> {
 		let ino = self.read_inode(inr)?;
 

--- a/rufs/src/ufs/xattr.rs
+++ b/rufs/src/ufs/xattr.rs
@@ -1,8 +1,7 @@
+use super::*;
 use crate::InodeNum;
 
-use super::*;
-
-impl Ufs {
+impl<R: Read + Seek> Ufs<R> {
 	fn iter_xattr<T>(
 		&mut self,
 		ino: &Inode,


### PR DESCRIPTION
Currently just walks the directory tree.

Required refactoring some parts of the code so that a UFS image in a memory buffer can be used instead of a backing file for performance reasons.

Already finds quite a few crashes, @realchonk is working on fixes for them.