### PR TITLE
implement support for FUSE2/OpenBSD (second try)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
@@ -108,6 +108,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,13 +152,22 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -154,10 +183,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
-name = "clap"
-version = "4.5.15"
+name = "clang-sys"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -175,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -187,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -230,6 +270,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "env_filter"
@@ -280,6 +326,7 @@ dependencies = [
  "clap-verbosity-flag",
  "cstr",
  "env_logger",
+ "fuse2rs",
  "fuser",
  "lazy_static",
  "libc",
@@ -290,6 +337,16 @@ dependencies = [
  "rufs",
  "tempfile",
  "xattr",
+]
+
+[[package]]
+name = "fuse2rs"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8316e54f1a37c6c64ce2a0f6393c61cbedcc8456e3dc76a1b824f69060a47afd"
+dependencies = [
+ "bindgen",
+ "libc",
 ]
 
 [[package]]
@@ -351,6 +408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,9 +433,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -380,6 +446,16 @@ dependencies = [
  "arbitrary",
  "cc",
  "once_cell",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
 ]
 
 [[package]]
@@ -401,6 +477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +492,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -471,6 +563,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -596,11 +698,18 @@ name = "rufs"
 version = "0.3.0"
 dependencies = [
  "bincode",
+ "fuse2rs",
  "fuser",
  "libc",
  "log",
  "tempfile",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -613,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags",
  "errno",
@@ -632,18 +741,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -670,9 +779,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -700,9 +809,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ bincode = "2.0.0-rc.3"
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.1"
 env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime"] }
+fuse2rs = "0.0.2"
 fuser = "0.14.0"
 libc = "0.2.155"
 log = "0.4.22"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,10 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - basic fuzzing framework ([#74](https://github.com/realchonk/fuse-ufs/pull/74))
 - pre-mount checks for verifying the filesystem ([#74](https://github.com/realchonk/fuse-ufs/pull/74))
+- support for OpenBSD/FUSE2 via fuse2rs ([#79](https://github.com/realchonk/fuse-ufs/pull/79))
 
 ### Changed
 
 - split project into binary and library part ([#74](https://github.com/realchonk/fuse-ufs/pull/74))
+- make fuser optional ([#79](https://github.com/realchonk/fuse-ufs/pull/79))
 
 ## [0.3.0] - 2024-08-22
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,9 @@
 ## Packages
 [![Packaging status](https://repology.org/badge/vertical-allrepos/fusefs:ufs.svg)](https://repology.org/project/fusefs:ufs/versions)
 
-- [Arch Linux AUR](https://aur.archlinux.org/packages/fuse-ufs)
-- FreeBSD (TODO)
-- [crates.io](https://crates.io/crates/fuse-ufs)
-
 ## Dependencies
 - rust >= 1.74.0
-- libfuse3
+- libfuse3 or libfuse2 (for fuse-ufs)
 
 ## Building from source
 ```sh

--- a/fuse-ufs/Cargo.toml
+++ b/fuse-ufs/Cargo.toml
@@ -11,15 +11,22 @@ documentation = "https://docs.rs/fuse-ufs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["fuse3"]
+fuse3 = ["dep:fuser", "rufs/fuser"]
+fuse2 = ["dep:fuse2rs", "rufs/fuse2rs"]
+
 [dependencies]
 anyhow.workspace = true
+cfg-if = "1.0.0"
 clap.workspace = true
 clap-verbosity-flag.workspace = true
 env_logger.workspace = true
-fuser.workspace = true
+fuse2rs = { workspace = true, optional = true }
+fuser = { workspace = true, optional = true }
 libc.workspace = true
 log.workspace = true
-rufs = { path = "../rufs", features = ["fuser"] }
+rufs = { path = "../rufs" }
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/fuse-ufs/src/cli.rs
+++ b/fuse-ufs/src/cli.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
-use fuser::MountOption;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -25,7 +24,9 @@ pub struct Cli {
 }
 
 impl Cli {
-	pub fn options(&self) -> Vec<MountOption> {
+	#[cfg(feature = "fuse3")]
+	pub fn options(&self) -> Vec<fuser::MountOption> {
+		use fuser::MountOption;
 		let mut opts = vec![
 			MountOption::FSName("fusefs".into()),
 			MountOption::Subtype("ufs".into()),
@@ -58,5 +59,50 @@ impl Cli {
 		}
 
 		opts
+	}
+
+	#[cfg(feature = "fuse2")]
+	pub fn options(&self) -> anyhow::Result<Vec<fuse2rs::MountOption>> {
+		use std::ffi::CString;
+
+		use fuse2rs::MountOption;
+
+		let mut opts = vec![MountOption::DefaultPermissions, MountOption::Ro];
+
+		if self.foreground {
+			opts.push(MountOption::Foreground);
+		}
+
+		if self
+			.verbose
+			.log_level()
+			.map_or(false, |l| l >= clap_verbosity_flag::Level::Debug)
+		{
+			opts.push(MountOption::Debug);
+		}
+
+		for opt in &self.options {
+			let opt = match opt.as_str() {
+				"debug" => MountOption::Debug,
+				"allow_other" => MountOption::AllowOther,
+				"async" => MountOption::Async,
+				"atime" => MountOption::Atime,
+				"default_permissions" => continue,
+				"dev" => MountOption::Dev,
+				"exec" => MountOption::Exec,
+				"noatime" => MountOption::NoAtime,
+				"nodev" => MountOption::NoDev,
+				"noexec" => MountOption::NoExec,
+				"nosuid" => MountOption::NoSuid,
+				"ro" => continue,
+				"rw" => panic!("rw is not yet supported"),
+				"suid" => MountOption::Suid,
+				"sync" => MountOption::Sync,
+				custom => MountOption::Custom(CString::new(custom)?),
+			};
+			opts.push(opt);
+		}
+
+		Ok(opts)
 	}
 }

--- a/fuse-ufs/src/fuse2.rs
+++ b/fuse-ufs/src/fuse2.rs
@@ -1,0 +1,104 @@
+use std::{
+	ffi::CString,
+	io::{Error, Result},
+	os::unix::ffi::OsStrExt,
+	path::Path,
+};
+
+use fuse2rs::*;
+use rufs::InodeNum;
+
+use crate::Fs;
+
+impl Fs {
+	fn lookup(&mut self, path: &Path) -> Result<InodeNum> {
+		if !path.is_absolute() {
+			return Err(Error::from_raw_os_error(libc::EINVAL));
+		}
+
+		let mut inr = InodeNum::ROOT;
+		for comp in path.components().skip(1) {
+			inr = self.ufs.dir_lookup(inr, comp.as_os_str())?;
+		}
+		Ok(inr)
+	}
+}
+
+impl Filesystem for Fs {
+	fn getattr(&mut self, _req: &Request, path: &Path) -> Result<FileAttr> {
+		let inr = self.lookup(path)?;
+		let ino = self.ufs.inode_attr(inr)?;
+		Ok(ino.into())
+	}
+
+	fn readdir(
+		&mut self,
+		_req: &Request,
+		path: &Path,
+		off: u64,
+		filler: &mut DirFiller,
+		_info: &FileInfo,
+	) -> Result<()> {
+		let pinr = self.lookup(path)?;
+
+		// TODO
+		if off != 0 {
+			return Ok(());
+		}
+
+		self.ufs.dir_iter(pinr, |name, _inr, _kind| {
+			let name = CString::new(name.as_bytes().to_vec()).unwrap();
+			if filler.push(&name) {
+				None
+			} else {
+				Some(())
+			}
+		})?;
+
+		Ok(())
+	}
+
+	fn read(
+		&mut self,
+		_req: &Request,
+		path: &Path,
+		off: u64,
+		buf: &mut [u8],
+		_info: &FileInfo,
+	) -> Result<usize> {
+		let inr = self.lookup(path)?;
+		let num = self.ufs.inode_read(inr, off, buf)?;
+		Ok(num)
+	}
+
+	fn readlink(&mut self, _req: &Request, path: &Path, buf: &mut [u8]) -> Result<()> {
+		let inr = self.lookup(path)?;
+		let link = self.ufs.symlink_read(inr)?;
+
+		let len = link.len();
+
+		if len >= buf.len() {
+			return Err(Error::from_raw_os_error(libc::ENAMETOOLONG));
+		}
+
+		buf[0..len].copy_from_slice(&link[0..len]);
+		buf[len] = b'\0';
+
+		Ok(())
+	}
+
+	fn statfs(&mut self, _req: &Request, _path: &Path) -> Result<Statfs> {
+		let info = self.ufs.info();
+
+		Ok(Statfs {
+			bsize:  info.bsize,
+			frsize: info.fsize,
+			blocks: info.blocks,
+			bfree:  info.bfree,
+			bavail: info.bfree,
+			files:  info.files,
+			ffree:  info.ffree,
+			favail: info.ffree,
+		})
+	}
+}

--- a/fuse-ufs/src/fuse3.rs
+++ b/fuse-ufs/src/fuse3.rs
@@ -1,0 +1,224 @@
+use std::{
+	ffi::{c_int, OsStr},
+	io::{Error as IoError, ErrorKind, Result as IoResult},
+	time::Duration,
+};
+
+use fuser::{FileAttr, Filesystem, KernelConfig, Request};
+use rufs::InodeNum;
+
+use crate::Fs;
+
+const MAX_CACHE: Duration = Duration::MAX;
+
+fn run<T>(f: impl FnOnce() -> IoResult<T>) -> Result<T, c_int> {
+	f().map_err(|e| {
+		log::error!("Error: {e}");
+		e.raw_os_error().unwrap_or(libc::EIO)
+	})
+}
+
+fn transino(inr: u64) -> IoResult<InodeNum> {
+	if inr == fuser::FUSE_ROOT_ID {
+		Ok(InodeNum::ROOT)
+	} else {
+		let inr = inr
+			.try_into()
+			.map_err(|_| IoError::from_raw_os_error(libc::EINVAL))?;
+		Ok(unsafe { InodeNum::new(inr) })
+	}
+}
+
+impl Filesystem for Fs {
+	fn init(&mut self, _req: &Request<'_>, _config: &mut KernelConfig) -> Result<(), c_int> {
+		Ok(())
+	}
+
+	fn destroy(&mut self) {}
+
+	fn getattr(&mut self, _req: &Request<'_>, ino: u64, reply: fuser::ReplyAttr) {
+		// TODO: don't use read_inode()
+		let f = || {
+			let inr = transino(ino)?;
+			let st: FileAttr = self.ufs.inode_attr(inr)?.into();
+			Ok(st)
+		};
+		match run(f) {
+			Ok(x) => reply.attr(&MAX_CACHE, &x),
+			Err(e) => reply.error(e),
+		}
+	}
+
+	fn open(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
+		let _ino = transino(ino);
+		reply.opened(0, 0);
+	}
+
+	fn opendir(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
+		let _ino = transino(ino);
+		reply.opened(0, 0);
+	}
+
+	// TODO: use offset in a less stupid way
+	fn readdir(
+		&mut self,
+		_req: &Request<'_>,
+		inr: u64,
+		_fh: u64,
+		offset: i64,
+		mut reply: fuser::ReplyDirectory,
+	) {
+		let f = || {
+			let inr = transino(inr)?;
+			if offset != 0 {
+				return Ok(());
+			}
+
+			let mut i = 0;
+
+			self.ufs.dir_iter(inr, |name, inr, kind| {
+				i += 1;
+				if i > offset && reply.add(inr.get64(), i, kind.into(), name) {
+					return Some(());
+				}
+				None
+			})?;
+
+			Ok(())
+		};
+		match run(f) {
+			Ok(_) => reply.ok(),
+			Err(e) => reply.error(e),
+		}
+	}
+
+	fn lookup(&mut self, _req: &Request<'_>, pinr: u64, name: &OsStr, reply: fuser::ReplyEntry) {
+		let mut f = || {
+			let pinr = transino(pinr)?;
+			let inr = self.ufs.dir_lookup(pinr, name)?;
+			let st = self.ufs.inode_attr(inr)?;
+			Ok::<_, IoError>((st.gen, st.into()))
+		};
+
+		match f() {
+			Ok((gen, st)) => reply.entry(&Duration::ZERO, &st, gen.into()),
+			Err(e) => {
+				if e.kind() != ErrorKind::NotFound {
+					log::error!("Error: {e}");
+				}
+				reply.error(e.raw_os_error().unwrap_or(libc::EIO))
+			}
+		}
+	}
+
+	fn read(
+		&mut self,
+		_req: &Request<'_>,
+		inr: u64,
+		_fh: u64,
+		offset: i64,
+		size: u32,
+		_flags: i32,
+		_lock_owner: Option<u64>,
+		reply: fuser::ReplyData,
+	) {
+		let f = || {
+			let inr = transino(inr)?;
+			let mut buffer = vec![0u8; size as usize];
+			let n = self.ufs.inode_read(inr, offset as u64, &mut buffer)?;
+			buffer.shrink_to(n);
+			Ok(buffer)
+		};
+
+		match run(f) {
+			Ok(buf) => reply.data(&buf),
+			Err(e) => reply.error(e),
+		}
+	}
+
+	fn statfs(&mut self, _req: &Request<'_>, _ino: u64, reply: fuser::ReplyStatfs) {
+		let info = self.ufs.info();
+		reply.statfs(
+			info.blocks,
+			info.bfree,
+			info.bfree,
+			info.files,
+			info.ffree,
+			info.bsize,
+			255,
+			info.fsize,
+		)
+	}
+
+	fn readlink(&mut self, _req: &Request<'_>, inr: u64, reply: fuser::ReplyData) {
+		let f = || {
+			let inr = transino(inr)?;
+			self.ufs.symlink_read(inr)
+		};
+		match run(f) {
+			Ok(x) => reply.data(&x),
+			Err(e) => reply.error(e),
+		}
+	}
+
+	fn listxattr(&mut self, _req: &Request<'_>, inr: u64, size: u32, reply: fuser::ReplyXattr) {
+		enum R {
+			Len(u32),
+			Data(Vec<u8>),
+		}
+
+		let f = || {
+			let inr = transino(inr)?;
+			if size == 0 {
+				let len = self.ufs.xattr_list_len(inr)?;
+				Ok(R::Len(len))
+			} else {
+				let data = self.ufs.xattr_list(inr)?;
+				Ok(R::Data(data))
+			}
+		};
+
+		match run(f) {
+			Ok(R::Data(data)) => reply.data(&data),
+			Ok(R::Len(len)) => reply.size(len),
+			Err(e) => reply.error(e),
+		}
+	}
+
+	fn getxattr(
+		&mut self,
+		_req: &Request<'_>,
+		inr: u64,
+		name: &OsStr,
+		size: u32,
+		reply: fuser::ReplyXattr,
+	) {
+		enum R {
+			Data(Vec<u8>),
+			TooShort,
+			Len(u32),
+		}
+
+		let f = || {
+			let inr = transino(inr)?;
+			if size == 0 {
+				let len = self.ufs.xattr_len(inr, name)?;
+				Ok(R::Len(len))
+			} else {
+				let data = self.ufs.xattr_read(inr, name)?;
+				if (size as usize) >= data.len() {
+					Ok(R::Data(data))
+				} else {
+					Ok(R::TooShort)
+				}
+			}
+		};
+
+		match run(f) {
+			Ok(R::Data(x)) => reply.data(&x),
+			Ok(R::TooShort) => reply.error(libc::ERANGE),
+			Ok(R::Len(l)) => reply.size(l),
+			Err(e) => reply.error(e),
+		}
+	}
+}

--- a/fuse-ufs/tests/integration.rs
+++ b/fuse-ufs/tests/integration.rs
@@ -108,7 +108,7 @@ fn harness(img: &Path) -> Harness {
 	waitfor(Duration::from_secs(5), || {
 		let s = nix::sys::statfs::statfs(d.path()).unwrap();
 		cfg_if! {
-			if #[cfg(any(target_os = "freebsd", target_os = "macos"))] {
+			if #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "openbsd"))] {
 				s.filesystem_type_name() == "fusefs.ufs"
 			} else if #[cfg(target_os = "linux")] {
 				s.filesystem_type() == nix::sys::statfs::FUSE_SUPER_MAGIC

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -13,9 +13,12 @@ documentation = "https://docs.rs/rufs"
 
 [features]
 fuser = ["dep:fuser"]
+fuse2rs = ["dep:fuse2rs"]
 
 [dependencies]
 bincode.workspace = true
+fuse2rs = { workspace = true, optional = true }
+
 fuser = { workspace = true, optional = true }
 libc.workspace = true
 log.workspace = true

--- a/rufs/src/inode.rs
+++ b/rufs/src/inode.rs
@@ -200,7 +200,50 @@ mod f {
 				atime:   a.atime,
 				mtime:   a.mtime,
 				ctime:   a.ctime,
-				crtime:  a.atime,
+				crtime:  a.btime,
+				kind:    a.kind.into(),
+				perm:    a.perm,
+				nlink:   a.nlink.into(),
+				uid:     a.uid,
+				gid:     a.gid,
+				rdev:    0,
+				blksize: a.blksize,
+				flags:   a.flags,
+			}
+		}
+	}
+}
+
+#[cfg(feature = "fuse2rs")]
+mod f2 {
+	use fuse2rs::{FileAttr, FileType};
+
+	use super::*;
+
+	impl From<InodeType> for FileType {
+		fn from(t: InodeType) -> Self {
+			match t {
+				InodeType::RegularFile => Self::RegularFile,
+				InodeType::Directory => Self::Directory,
+				InodeType::Symlink => Self::Symlink,
+				InodeType::Socket => Self::Socket,
+				InodeType::CharDevice => Self::CharDevice,
+				InodeType::BlockDevice => Self::BlockDevice,
+				InodeType::NamedPipe => Self::NamedPipe,
+			}
+		}
+	}
+
+	impl From<InodeAttr> for FileAttr {
+		fn from(a: InodeAttr) -> Self {
+			Self {
+				ino:     a.inr.get64(),
+				size:    a.size,
+				blocks:  a.blocks,
+				atime:   a.atime,
+				mtime:   a.mtime,
+				ctime:   a.ctime,
+				btime:   a.btime,
 				kind:    a.kind.into(),
 				perm:    a.perm,
 				nlink:   a.nlink.into(),

--- a/rufs/src/ufs/xattr.rs
+++ b/rufs/src/ufs/xattr.rs
@@ -69,7 +69,7 @@ impl<R: Read + Seek> Ufs<R> {
 		xname: &OsStr,
 		mut f: impl FnMut(&ExtattrHeader, &[u8]) -> T,
 	) -> IoResult<T> {
-		#[cfg(target_os = "freebsd")]
+		#[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"))]
 		const ERR: i32 = libc::ENOATTR;
 		#[cfg(target_os = "linux")]
 		const ERR: i32 = libc::ENODATA;


### PR DESCRIPTION
- fuse-ufs: make fuser optional
- fuse-ufs: add FUSE2 backend via fuse2rs
- rufs: add optional dependencies for fuser and fuse2rs