### PR TITLE
rufs: fix calculation of fragment blocks

### DIFF
--- a/rufs/src/ufs/inode.rs
+++ b/rufs/src/ufs/inode.rs
@@ -93,9 +93,9 @@ impl<R: Read + Seek> Ufs<R> {
 			}
 		} else if offset < (bs * blocks + fs * frags) {
 			BlockInfo {
-				blkidx: blocks + (offset - blocks * bs) / fs,
-				off:    offset % fs,
-				size:   fs,
+				blkidx: blocks,
+				off:    offset % bs,
+				size:   frags * fs,
 			}
 		} else {
 			panic!("out of bounds");
@@ -214,7 +214,7 @@ impl<R: Read + Seek> Ufs<R> {
 		if blkidx < blocks {
 			bs as usize
 		} else if blkidx < blocks + frags {
-			fs as usize
+			(fs * frags) as usize
 		} else {
 			panic!("out of bounds: {blkidx}, blocks: {blocks}, frags: {frags}");
 		}


### PR DESCRIPTION
An inode can contain 0 or more blocks (32K)
and upto 1 partial block (4K-28K).

Previously it was assumed, that an inode could
contain 0-7 individual fragment blocks (4K each).

Due to FreeBSD's kernel UFS being very generous
during block allocation, it never allocated
fragmented blocks.