### PR TITLE
Performance Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,49 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -86,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +149,21 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "bincode"
@@ -133,7 +191,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -146,6 +204,12 @@ dependencies = [
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -169,6 +233,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "cast"
@@ -309,6 +379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +523,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,10 +565,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "foldhash"
-version = "0.1.4"
+name = "findshlibs"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fuse-ufs"
@@ -547,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -584,6 +710,34 @@ name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
 
 [[package]]
 name = "is-terminal"
@@ -709,6 +863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,10 +894,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nix"
@@ -741,7 +934,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -753,7 +946,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -770,12 +963,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -798,6 +1010,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -847,6 +1082,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "pprof"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebbe2f8898beba44815fdc9e5a4ae9c929e21c5dc29b0c774a15555f7f58d6d0"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "criterion",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -902,6 +1160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -999,6 +1266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1308,15 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rgb"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rstest"
@@ -1082,8 +1367,15 @@ dependencies = [
  "libc",
  "log",
  "lru",
+ "pprof",
  "tempfile",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -1106,7 +1398,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1133,6 +1425,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1185,10 +1483,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "symbolic-common"
+version = "12.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1150bdda9314f6cfeeea801c23f5593c6e6a6c72e64f67e48d723a12b8efdb"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f66537def48fbc704a92e4fdaab7833bc7cb2255faca8182592fb5fa617eb82"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -1221,6 +1554,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1600,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtue"
@@ -1530,7 +1895,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +455,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "fuse-ufs"
@@ -542,6 +560,17 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -684,6 +713,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "memchr"
@@ -1043,6 +1081,7 @@ dependencies = [
  "fuser",
  "libc",
  "log",
+ "lru",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +130,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -145,6 +157,18 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -183,6 +207,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clang-sys"
@@ -250,6 +301,73 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "cstr"
@@ -417,10 +535,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -430,12 +575,27 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
@@ -469,6 +629,16 @@ checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -562,10 +732,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "page_size"
@@ -582,6 +767,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -728,6 +941,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +1038,7 @@ name = "rufs"
 version = "0.5.0"
 dependencies = [
  "bincode",
+ "criterion",
  "fuse2rs",
  "fuser",
  "libc",
@@ -841,6 +1075,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +1119,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -915,6 +1182,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +1225,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1247,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -977,6 +1332,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libc = "0.2.155"
 log = "0.4.22"
 lru = "0.13.0"
 rufs = { version = "0.5.0", path = "rufs" }
+pprof = "0.14.0"
 
 # Dev dependencies
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rufs = { version = "0.5.0", path = "rufs" }
 # Dev dependencies
 assert_cmd = "2.0"
 cstr = "0.2.12"
+criterion = "0.5.1"
 lazy_static = "1.4.0"
 nix = { version = "0.28.0", features = ["fs", "dir"] }
 rstest = { version = "0.19.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ fuse2rs = "0.1.2"
 fuser = "0.15.1"
 libc = "0.2.155"
 log = "0.4.22"
+lru = "0.13.0"
 rufs = { version = "0.5.0", path = "rufs" }
 
 # Dev dependencies

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 FUSE_UFS_FLAGS = -p fuse-ufs --ignore-rust-version --no-default-features -F $$(uname)
 
-BENCH = cargo bench -p fuse-ufs
+BENCH = cargo bench -p rufs
 
 SRC != find rufs/src fuse-ufs/src -name '*.rs'
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 FUSE_UFS_FLAGS = -p fuse-ufs --ignore-rust-version --no-default-features -F $$(uname)
 
+BENCH = cargo bench -p fuse-ufs
+
 SRC != find rufs/src fuse-ufs/src -name '*.rs'
 
 all: fuse-ufs-bin
@@ -26,7 +28,11 @@ test:
 	cargo test ${FUSE_UFS_FLAGS}
 
 bench:
-	cargo bench
+	${BENCH} --no-default-features > bench.baseline
+	${BENCH} --no-default-features -F icache > bench.icache
+	${BENCH} --no-default-features -F dcache > bench.dcache
+	${BENCH} --no-default-features -F bcache > bench.bcache
+	${BENCH} > bench.cache
 
 fuz:
 	mkdir -p fuzz/corpus/ufs/

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ test:
 	cargo test -p rufs --ignore-rust-version
 	cargo test ${FUSE_UFS_FLAGS}
 
+bench:
+	cargo bench
+
 fuz:
 	mkdir -p fuzz/corpus/ufs/
 	unzstd -o fuzz/corpus/ufs/ufs-big.img -kf resources/ufs-big.img.zst

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ bench:
 	${BENCH} --no-default-features > bench.baseline
 	${BENCH} --no-default-features -F icache > bench.icache
 	${BENCH} --no-default-features -F dcache > bench.dcache
-	${BENCH} --no-default-features -F bcache > bench.bcache
-	${BENCH} > bench.cache
+	${BENCH} > bench.all
 
 flame:
 	${BENCH} -F 'bcache' -- --profile-time 5

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 FUSE_UFS_FLAGS = -p fuse-ufs --ignore-rust-version --no-default-features -F $$(uname)
 
-BENCH = cargo bench -p rufs
+BENCH = cargo bench -p rufs --bench bench
 
 SRC != find rufs/src fuse-ufs/src -name '*.rs'
 
@@ -33,6 +33,9 @@ bench:
 	${BENCH} --no-default-features -F dcache > bench.dcache
 	${BENCH} --no-default-features -F bcache > bench.bcache
 	${BENCH} > bench.cache
+
+flame:
+	${BENCH} -F 'bcache' -- --profile-time 5
 
 fuz:
 	mkdir -p fuzz/corpus/ufs/

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -18,7 +18,6 @@ fuse2rs = ["dep:fuse2rs"]
 lru = ["dep:lru"]
 icache = ["lru"]
 dcache = ["lru"]
-bcache = ["lru"]
 
 [dependencies]
 bincode.workspace = true

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -21,6 +21,7 @@ fuse2rs = { workspace = true, optional = true }
 fuser = { workspace = true, optional = true }
 libc.workspace = true
 log.workspace = true
+lru.workspace = true
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -12,8 +12,13 @@ documentation = "https://docs.rs/rufs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["icache", "dcache", "bcache"]
 fuser = ["dep:fuser"]
 fuse2rs = ["dep:fuse2rs"]
+lru = ["dep:lru"]
+icache = ["lru"]
+dcache = ["lru"]
+bcache = ["lru"]
 
 [dependencies]
 bincode.workspace = true
@@ -21,7 +26,7 @@ fuse2rs = { workspace = true, optional = true }
 fuser = { workspace = true, optional = true }
 libc.workspace = true
 log.workspace = true
-lru.workspace = true
+lru = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -18,13 +18,17 @@ fuse2rs = ["dep:fuse2rs"]
 [dependencies]
 bincode.workspace = true
 fuse2rs = { workspace = true, optional = true }
-
 fuser = { workspace = true, optional = true }
 libc.workspace = true
 log.workspace = true
 
 [dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
 tempfile.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/rufs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["icache", "dcache", "bcache"]
+default = ["icache", "dcache"]
 fuser = ["dep:fuser"]
 fuse2rs = ["dep:fuse2rs"]
 lru = ["dep:lru"]

--- a/rufs/Cargo.toml
+++ b/rufs/Cargo.toml
@@ -30,6 +30,7 @@ lru = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }
+pprof = { workspace = true, features = ["criterion", "flamegraph"] }
 tempfile.workspace = true
 
 [lints.rust]

--- a/rufs/benches/bench.rs
+++ b/rufs/benches/bench.rs
@@ -1,0 +1,228 @@
+use std::{fs::File, hint::black_box, path::{Component, Path, PathBuf}, process::Command, time::Duration};
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use rufs::{InodeNum, InodeType, Ufs};
+
+// This has around 1800 files.
+const IMAGE: &str = "openbsd76-root";
+
+fn prepare_image(filename: &str) -> PathBuf {
+	let mut zimg = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+	zimg.push("../resources");
+	zimg.push(filename);
+	zimg.set_extension("img.zst");
+
+	let mut img = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+	img.push(filename);
+
+	// If the golden image doesn't exist, or is out of date, rebuild it
+	// Note: we can't accurately compare the two timestamps with less than 1
+	// second granularity due to a zstd bug.
+	// https://github.com/facebook/zstd/issues/3748
+	let zmtime = std::fs::metadata(&zimg).unwrap().modified().unwrap();
+	let mtime = std::fs::metadata(&img);
+	if mtime.is_err() || (mtime.unwrap().modified().unwrap() + Duration::from_secs(1)) < zmtime {
+		Command::new("unzstd")
+			.arg("-f")
+			.arg("-o")
+			.arg(&img)
+			.arg(&zimg)
+			.output()
+			.expect("Uncompressing golden image failed");
+	}
+	img
+}
+
+fn lookup(ufs: &mut Ufs<File>, path: &Path) -> InodeNum {
+	let mut comps = path.components();
+	assert_eq!(comps.next(), Some(Component::RootDir));
+	let mut inr = InodeNum::ROOT;
+	for c in comps {
+		match c {
+			Component::Normal(name) => {
+				inr = ufs.dir_lookup(inr, name).unwrap();
+			},
+			_ => unreachable!("unexpected path component: {c:?}")
+		}
+	}
+
+	inr
+}
+
+/// just open the image
+fn open(c: &mut Criterion) {
+	let img = prepare_image(IMAGE);
+	c.bench_function("open", |b| b.iter(|| {
+		let ufs = Ufs::open(&img, false).unwrap();
+		black_box(ufs);
+	}));
+}
+
+fn read(c: &mut Criterion) {
+	let img = prepare_image(IMAGE);
+	let path = Path::new("/bsd");
+	let mut group = c.benchmark_group("read");
+
+	let mut ufs = Ufs::open(&img, false).unwrap();
+	let inr = lookup(&mut ufs, path);
+	let meta = ufs.inode_attr(inr).unwrap();
+
+	group.measurement_time(Duration::from_secs(30));
+	group.throughput(Throughput::Bytes(meta.size));
+	group.sample_size(50);
+
+	for bs in [1048576, 65536, 16384, 4096, 512] {
+		let mut buf = vec![0u8; bs];
+		let len = buf.len() as u64;
+		let num = meta.size / len;
+		group.bench_function(bs.to_string(), |b| b.iter(|| {
+			for i in 0..num {
+				let _ = black_box(ufs.inode_read(inr, black_box(i * len), black_box(&mut buf))).unwrap();
+			}
+		}));
+	}
+
+	group.finish();
+}
+
+fn find(c: &mut Criterion) {
+	let img = prepare_image(IMAGE);
+	let mut group = c.benchmark_group("find");
+
+
+	// traverse through the entire filesystem, equivalent to running `find -x mp`
+	group.measurement_time(Duration::from_secs(15));
+	group.bench_function("direct", |b| b.iter(|| {
+		fn traverse(ufs: &mut Ufs<File>, dinr: InodeNum) {
+			let mut subdirs = Vec::new();
+			let _ = ufs.dir_iter(dinr, |name, inr, kind| {
+				let name = black_box(name);
+				if name == "." || name == ".." {
+					return None;
+				}
+
+				if black_box(kind) == InodeType::Directory {
+					subdirs.push(black_box(inr));
+				}
+
+				None::<()>
+			}).unwrap();
+
+			for dir in subdirs {
+				traverse(ufs, dir);
+			}
+		}
+		let mut ufs = Ufs::open(&img, false).unwrap();
+		traverse(&mut ufs, InodeNum::ROOT)
+	}));
+
+
+	// similar to `direct`, but perform path lookups instead
+	group.measurement_time(Duration::from_secs(30));
+	group.bench_function("lookup", |b| b.iter(|| {
+		fn traverse(ufs: &mut Ufs<File>, path: &Path) {
+			let mut subdirs = Vec::new();
+			let dinr = black_box(lookup(ufs, path));
+			let _ = ufs.dir_iter(dinr, |name, _inr, kind| {
+				let name = black_box(name);
+				if name == "." || name == ".." {
+					return None;
+				}
+
+				if black_box(kind) == InodeType::Directory {
+					subdirs.push(path.join(name));
+				}
+
+				None::<()>
+			}).unwrap();
+
+			for dir in subdirs {
+				traverse(ufs, &dir);
+			}
+		}
+
+		let mut ufs = Ufs::open(&img, false).unwrap();
+		traverse(&mut ufs, Path::new("/"));
+	}));
+
+	// similar to `lookup`, but also perform stat() on files
+	group.measurement_time(Duration::from_secs(30));
+	group.sample_size(50);
+	group.bench_function("lookup+stat", |b| b.iter(|| {
+		fn traverse(ufs: &mut Ufs<File>, path: &Path) {
+			let inr = black_box(lookup(ufs, path));
+			let meta = black_box(ufs.inode_attr(inr).unwrap());
+
+			match meta.kind {
+				InodeType::Directory => {
+					let mut children = Vec::new();
+					let _ = ufs.dir_iter(inr, |name, _inr, _kind| {
+						let name = black_box(name);
+						if name != "." && name != ".." {
+							children.push(path.join(name));
+						}
+						None::<()>
+					}).unwrap();
+
+					for child in children {
+						traverse(ufs, &child);
+					}
+				},
+				_ => {},
+			}
+		}
+
+		let mut ufs = Ufs::open(&img, false).unwrap();
+		traverse(&mut ufs, Path::new("/"));
+	}));
+
+	// similar to `lookup+stat`, but also read files and links
+	group.measurement_time(Duration::from_secs(60));
+	group.sample_size(10);
+	for bs in [65536, 16384, 4096, 512] {
+		let mut buf = vec![0u8; bs];
+		group.bench_function(format!("lookup+stat+read-{bs}"), |b| b.iter(|| {
+			fn traverse(ufs: &mut Ufs<File>, path: &Path, buf: &mut [u8]) {
+				let inr = black_box(lookup(ufs, path));
+				let meta = black_box(ufs.inode_attr(inr).unwrap());
+
+				match meta.kind {
+					InodeType::Directory => {
+						let mut children = Vec::new();
+						let _ = ufs.dir_iter(inr, |name, _inr, _kind| {
+							let name = black_box(name);
+							if name != "." && name != ".." {
+								children.push(path.join(name));
+							}
+							None::<()>
+						}).unwrap();
+
+						for child in children {
+							traverse(ufs, &child, buf);
+						}
+					},
+					InodeType::Symlink => {
+						let _ = black_box(ufs.symlink_read(inr).unwrap());
+					},
+					InodeType::RegularFile => {
+						let len = buf.len() as u64;
+						let num = meta.size / len;
+
+						for i in 0..num {
+							let _ = black_box(ufs.inode_read(inr, i * len, buf).unwrap());
+						}
+					},
+					_ => {},
+				}
+			}
+
+			let mut ufs = Ufs::open(&img, false).unwrap();
+			traverse(&mut ufs, Path::new("/"), &mut buf);
+		}));
+	}
+
+	group.finish();
+}
+
+criterion_group!(benches, open, read, find);
+criterion_main!(benches);

--- a/rufs/benches/bench.rs
+++ b/rufs/benches/bench.rs
@@ -1,7 +1,6 @@
 use std::{
 	fs::File,
 	hint::black_box,
-	os::raw::c_int,
 	path::{Path, PathBuf},
 	process::Command,
 	time::Duration,

--- a/rufs/benches/bench.rs
+++ b/rufs/benches/bench.rs
@@ -1,12 +1,9 @@
 use std::{
-	fs::File,
-	hint::black_box,
-	path::{Path, PathBuf},
-	process::Command,
-	time::Duration,
+	fs::File, hint::black_box, os::raw::c_int, path::{Path, PathBuf}, process::Command, time::Duration
 };
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use pprof::criterion::{Output, PProfProfiler};
 use rufs::{InodeNum, InodeType, Ufs};
 
 // This has around 1800 files.
@@ -253,5 +250,10 @@ fn find(c: &mut Criterion) {
 	group.finish();
 }
 
-criterion_group!(benches, open, read, find);
+criterion_group! {
+	name = benches;
+	config = Criterion::default()
+		.with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+	targets = open, read, find
+}
 criterion_main!(benches);

--- a/rufs/benches/bench.rs
+++ b/rufs/benches/bench.rs
@@ -1,4 +1,10 @@
-use std::{fs::File, hint::black_box, path::{Component, Path, PathBuf}, process::Command, time::Duration};
+use std::{
+	fs::File,
+	hint::black_box,
+	path::{Component, Path, PathBuf},
+	process::Command,
+	time::Duration,
+};
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use rufs::{InodeNum, InodeType, Ufs};
@@ -41,8 +47,8 @@ fn lookup(ufs: &mut Ufs<File>, path: &Path) -> InodeNum {
 		match c {
 			Component::Normal(name) => {
 				inr = ufs.dir_lookup(inr, name).unwrap();
-			},
-			_ => unreachable!("unexpected path component: {c:?}")
+			}
+			_ => unreachable!("unexpected path component: {c:?}"),
 		}
 	}
 
@@ -52,10 +58,12 @@ fn lookup(ufs: &mut Ufs<File>, path: &Path) -> InodeNum {
 /// just open the image
 fn open(c: &mut Criterion) {
 	let img = prepare_image(IMAGE);
-	c.bench_function("open", |b| b.iter(|| {
-		let ufs = Ufs::open(&img, false).unwrap();
-		black_box(ufs);
-	}));
+	c.bench_function("open", |b| {
+		b.iter(|| {
+			let ufs = Ufs::open(&img, false).unwrap();
+			black_box(ufs);
+		})
+	});
 }
 
 fn read(c: &mut Criterion) {
@@ -75,11 +83,14 @@ fn read(c: &mut Criterion) {
 		let mut buf = vec![0u8; bs];
 		let len = buf.len() as u64;
 		let num = meta.size / len;
-		group.bench_function(bs.to_string(), |b| b.iter(|| {
-			for i in 0..num {
-				let _ = black_box(ufs.inode_read(inr, black_box(i * len), black_box(&mut buf))).unwrap();
-			}
-		}));
+		group.bench_function(bs.to_string(), |b| {
+			b.iter(|| {
+				for i in 0..num {
+					let _ = black_box(ufs.inode_read(inr, black_box(i * len), black_box(&mut buf)))
+						.unwrap();
+				}
+			})
+		});
 	}
 
 	group.finish();
@@ -118,133 +129,148 @@ fn find(c: &mut Criterion) {
 
 	// traverse through the entire filesystem, equivalent to running `find -x mp`
 	group.measurement_time(Duration::from_secs(15));
-	group.bench_function("direct", |b| b.iter(|| {
-		fn traverse(ufs: &mut Ufs<File>, dinr: InodeNum) {
-			let mut subdirs = Vec::new();
-			let _ = ufs.dir_iter(dinr, |name, inr, kind| {
-				let name = black_box(name);
-				if name == "." || name == ".." {
-					return None;
+	group.bench_function("direct", |b| {
+		b.iter(|| {
+			fn traverse(ufs: &mut Ufs<File>, dinr: InodeNum) {
+				let mut subdirs = Vec::new();
+				let _ = ufs
+					.dir_iter(dinr, |name, inr, kind| {
+						let name = black_box(name);
+						if name == "." || name == ".." {
+							return None;
+						}
+
+						if black_box(kind) == InodeType::Directory {
+							subdirs.push(black_box(inr));
+						}
+
+						None::<()>
+					})
+					.unwrap();
+
+				for dir in subdirs {
+					traverse(ufs, dir);
 				}
-
-				if black_box(kind) == InodeType::Directory {
-					subdirs.push(black_box(inr));
-				}
-
-				None::<()>
-			}).unwrap();
-
-			for dir in subdirs {
-				traverse(ufs, dir);
 			}
-		}
-		let mut ufs = Ufs::open(&img, false).unwrap();
-		traverse(&mut ufs, InodeNum::ROOT)
-	}));
-
+			let mut ufs = Ufs::open(&img, false).unwrap();
+			traverse(&mut ufs, InodeNum::ROOT)
+		})
+	});
 
 	// similar to `direct`, but perform path lookups instead
 	group.measurement_time(Duration::from_secs(30));
-	group.bench_function("lookup", |b| b.iter(|| {
-		fn traverse(ufs: &mut Ufs<File>, path: &Path) {
-			let mut subdirs = Vec::new();
-			let dinr = black_box(lookup(ufs, path));
-			let _ = ufs.dir_iter(dinr, |name, _inr, kind| {
-				let name = black_box(name);
-				if name == "." || name == ".." {
-					return None;
+	group.bench_function("lookup", |b| {
+		b.iter(|| {
+			fn traverse(ufs: &mut Ufs<File>, path: &Path) {
+				let mut subdirs = Vec::new();
+				let dinr = black_box(lookup(ufs, path));
+				let _ = ufs
+					.dir_iter(dinr, |name, _inr, kind| {
+						let name = black_box(name);
+						if name == "." || name == ".." {
+							return None;
+						}
+
+						if black_box(kind) == InodeType::Directory {
+							subdirs.push(path.join(name));
+						}
+
+						None::<()>
+					})
+					.unwrap();
+
+				for dir in subdirs {
+					traverse(ufs, &dir);
 				}
-
-				if black_box(kind) == InodeType::Directory {
-					subdirs.push(path.join(name));
-				}
-
-				None::<()>
-			}).unwrap();
-
-			for dir in subdirs {
-				traverse(ufs, &dir);
 			}
-		}
 
-		let mut ufs = Ufs::open(&img, false).unwrap();
-		traverse(&mut ufs, Path::new("/"));
-	}));
+			let mut ufs = Ufs::open(&img, false).unwrap();
+			traverse(&mut ufs, Path::new("/"));
+		})
+	});
 
 	// similar to `lookup`, but also perform stat() on files
 	group.measurement_time(Duration::from_secs(30));
 	group.sample_size(50);
-	group.bench_function("lookup+stat", |b| b.iter(|| {
-		fn traverse(ufs: &mut Ufs<File>, path: &Path) {
-			let inr = black_box(lookup(ufs, path));
-			let meta = black_box(ufs.inode_attr(inr).unwrap());
-
-			match meta.kind {
-				InodeType::Directory => {
-					let mut children = Vec::new();
-					let _ = ufs.dir_iter(inr, |name, _inr, _kind| {
-						let name = black_box(name);
-						if name != "." && name != ".." {
-							children.push(path.join(name));
-						}
-						None::<()>
-					}).unwrap();
-
-					for child in children {
-						traverse(ufs, &child);
-					}
-				},
-				_ => {},
-			}
-		}
-
-		let mut ufs = Ufs::open(&img, false).unwrap();
-		traverse(&mut ufs, Path::new("/"));
-	}));
-
-	// similar to `lookup+stat`, but also read files and links
-	group.measurement_time(Duration::from_secs(60));
-	group.sample_size(10);
-	for bs in [65536, 16384, 4096, 512] {
-		let mut buf = vec![0u8; bs];
-		group.bench_function(format!("lookup+stat+read-{bs}"), |b| b.iter(|| {
-			fn traverse(ufs: &mut Ufs<File>, path: &Path, buf: &mut [u8]) {
+	group.bench_function("lookup+stat", |b| {
+		b.iter(|| {
+			fn traverse(ufs: &mut Ufs<File>, path: &Path) {
 				let inr = black_box(lookup(ufs, path));
 				let meta = black_box(ufs.inode_attr(inr).unwrap());
 
 				match meta.kind {
 					InodeType::Directory => {
 						let mut children = Vec::new();
-						let _ = ufs.dir_iter(inr, |name, _inr, _kind| {
-							let name = black_box(name);
-							if name != "." && name != ".." {
-								children.push(path.join(name));
-							}
-							None::<()>
-						}).unwrap();
+						let _ = ufs
+							.dir_iter(inr, |name, _inr, _kind| {
+								let name = black_box(name);
+								if name != "." && name != ".." {
+									children.push(path.join(name));
+								}
+								None::<()>
+							})
+							.unwrap();
 
 						for child in children {
-							traverse(ufs, &child, buf);
+							traverse(ufs, &child);
 						}
-					},
-					InodeType::Symlink => {
-						let _ = black_box(ufs.symlink_read(inr).unwrap());
-					},
-					InodeType::RegularFile => {
-						let len = buf.len() as u64;
-						let num = meta.size / len;
-
-						for i in 0..num {
-							let _ = black_box(ufs.inode_read(inr, i * len, buf).unwrap());
-						}
-					},
-					_ => {},
+					}
+					_ => {}
 				}
 			}
 
 			let mut ufs = Ufs::open(&img, false).unwrap();
-			traverse(&mut ufs, Path::new("/"), &mut buf);
-		}));
+			traverse(&mut ufs, Path::new("/"));
+		})
+	});
+
+	// similar to `lookup+stat`, but also read files and links
+	group.measurement_time(Duration::from_secs(60));
+	group.sample_size(10);
+	for bs in [65536, 16384, 4096, 512] {
+		let mut buf = vec![0u8; bs];
+		group.bench_function(format!("lookup+stat+read-{bs}"), |b| {
+			b.iter(|| {
+				fn traverse(ufs: &mut Ufs<File>, path: &Path, buf: &mut [u8]) {
+					let inr = black_box(lookup(ufs, path));
+					let meta = black_box(ufs.inode_attr(inr).unwrap());
+
+					match meta.kind {
+						InodeType::Directory => {
+							let mut children = Vec::new();
+							let _ = ufs
+								.dir_iter(inr, |name, _inr, _kind| {
+									let name = black_box(name);
+									if name != "." && name != ".." {
+										children.push(path.join(name));
+									}
+									None::<()>
+								})
+								.unwrap();
+
+							for child in children {
+								traverse(ufs, &child, buf);
+							}
+						}
+						InodeType::Symlink => {
+							let _ = black_box(ufs.symlink_read(inr).unwrap());
+						}
+						InodeType::RegularFile => {
+							let len = buf.len() as u64;
+							let num = meta.size / len;
+
+							for i in 0..num {
+								let _ = black_box(ufs.inode_read(inr, i * len, buf).unwrap());
+							}
+						}
+						_ => {}
+					}
+				}
+
+				let mut ufs = Ufs::open(&img, false).unwrap();
+				traverse(&mut ufs, Path::new("/"), &mut buf);
+			})
+		});
 	}
 
 	group.finish();

--- a/rufs/benches/bench.rs
+++ b/rufs/benches/bench.rs
@@ -192,9 +192,38 @@ fn find(c: &mut Criterion) {
 	// similar to `lookup`, but also perform stat() on files
 	group.measurement_time(Duration::from_secs(30));
 	group.sample_size(50);
-	group.bench_function("lookup+stat", |b| {
-		b.iter(|| {
-			fn traverse(ufs: &mut Ufs<File>, path: &Path) {
+	group.bench_function("lookup+stat", |b| b.iter(|| {
+		fn traverse(ufs: &mut Ufs<File>, path: &Path) {
+			let inr = black_box(lookup(ufs, path));
+			let meta = black_box(ufs.inode_attr(inr).unwrap());
+
+			if meta.kind == InodeType::Directory {
+				let mut children = Vec::new();
+				let _ = ufs.dir_iter(inr, |name, _inr, _kind| {
+					let name = black_box(name);
+					if name != "." && name != ".." {
+						children.push(path.join(name));
+					}
+					None::<()>
+				}).unwrap();
+
+				for child in children {
+					traverse(ufs, &child);
+				}
+			}
+		}
+
+		let mut ufs = Ufs::open(&img, false).unwrap();
+		traverse(&mut ufs, Path::new("/"));
+	}));
+
+	// similar to `lookup+stat`, but also read files and links
+	group.measurement_time(Duration::from_secs(60));
+	group.sample_size(10);
+	for bs in [65536, 16384, 4096, 512] {
+		let mut buf = vec![0u8; bs];
+		group.bench_function(format!("lookup+stat+read-{bs}"), |b| b.iter(|| {
+			fn traverse(ufs: &mut Ufs<File>, path: &Path, buf: &mut [u8]) {
 				let inr = black_box(lookup(ufs, path));
 				let meta = black_box(ufs.inode_attr(inr).unwrap());
 
@@ -212,7 +241,7 @@ fn find(c: &mut Criterion) {
 							.unwrap();
 
 						for child in children {
-							traverse(ufs, &child);
+							traverse(ufs, &child, buf);
 						}
 					}
 					_ => {}
@@ -220,9 +249,9 @@ fn find(c: &mut Criterion) {
 			}
 
 			let mut ufs = Ufs::open(&img, false).unwrap();
-			traverse(&mut ufs, Path::new("/"));
-		})
-	});
+			traverse(&mut ufs, Path::new("/"), &mut buf);
+		}));
+	}
 
 	// similar to `lookup+stat`, but also read files and links
 	group.measurement_time(Duration::from_secs(60));

--- a/rufs/src/blockreader.rs
+++ b/rufs/src/blockreader.rs
@@ -1,5 +1,8 @@
 use std::{
-	fs::File, io::{self, BufRead, Read, Result as IoResult, Seek, SeekFrom, Write}, os::unix::fs::MetadataExt, path::Path
+	fs::File,
+	io::{self, BufRead, Read, Result as IoResult, Seek, SeekFrom, Write},
+	os::unix::fs::MetadataExt,
+	path::Path,
 };
 
 pub trait Backend: Read + Write + Seek {}
@@ -55,11 +58,12 @@ impl<T: Backend> BlockReader<T> {
 		#[cfg(feature = "bcache")]
 		if let Some(cached) = self.cache.get(&pos) {
 			self.block.copy_from_slice(cached);
-			self.inner.seek(SeekFrom::Current(self.block.len() as i64))?;
+			self.inner
+				.seek(SeekFrom::Current(self.block.len() as i64))?;
 			self.idx = 0;
-			return Ok(())
+			return Ok(());
 		}
-		
+
 		self.block.fill(0u8);
 		let mut num = 0;
 		while num < self.block.len() {
@@ -133,7 +137,7 @@ impl<T: Backend> Write for BlockReader<T> {
 
 		#[cfg(feature = "bcache")]
 		self.cache.push(pos, self.block.clone());
-		
+
 		let mut num = 0;
 		while num < self.block.len() {
 			match self.inner.write(&self.block[num..])? {

--- a/rufs/src/data.rs
+++ b/rufs/src/data.rs
@@ -41,7 +41,7 @@ pub type UfsDaddr = i64;
 pub const DIRBLKSIZE: usize = 512;
 
 /// UFS-native inode number type
-#[derive(Debug, Decode, Encode, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Decode, Encode, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct InodeNum(u32);
 impl InodeNum {
@@ -336,7 +336,7 @@ pub enum InodeData {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Encode)]
+#[derive(Debug, Encode, Clone)]
 pub struct Inode {
 	pub mode:      u16,                    //   0: IFMT, permissions; see below.
 	pub nlink:     u16,                    //   2: File link count.

--- a/rufs/src/lib.rs
+++ b/rufs/src/lib.rs
@@ -6,6 +6,9 @@ mod decoder;
 mod inode;
 mod ufs;
 
+/// Number of inodes to store in a cache.
+const ICACHE_SIZE: usize = 1024;
+
 #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"))]
 pub const ENOATTR: i32 = libc::ENOATTR;
 #[cfg(target_os = "linux")]

--- a/rufs/src/lib.rs
+++ b/rufs/src/lib.rs
@@ -7,18 +7,26 @@ mod inode;
 mod ufs;
 
 /// Number of inodes to store in a cache.
+#[cfg(feature = "icache")]
 const ICACHE_SIZE: usize = 1024;
 
 /// Number of blocks cached.
+#[cfg(feature = "bcache")]
 const BCACHE_SIZE: usize = 16;
 
 /// Number of directory entries to cache.
+#[cfg(feature = "dcache")]
 const DCACHE_SIZE: usize = 1024;
 
 #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"))]
 pub const ENOATTR: i32 = libc::ENOATTR;
 #[cfg(target_os = "linux")]
 pub const ENOATTR: i32 = libc::ENODATA;
+
+#[cfg(feature = "lru")]
+fn new_lru<K: std::hash::Hash + Eq, V>(size: usize) -> lru::LruCache<K, V> {
+	lru::LruCache::new(std::num::NonZeroUsize::new(size).unwrap())
+}
 
 pub use crate::{
 	blockreader::{Backend, BlockReader},

--- a/rufs/src/lib.rs
+++ b/rufs/src/lib.rs
@@ -9,6 +9,9 @@ mod ufs;
 /// Number of inodes to store in a cache.
 const ICACHE_SIZE: usize = 1024;
 
+/// Number of blocks cached.
+const BCACHE_SIZE: usize = 16;
+
 #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"))]
 pub const ENOATTR: i32 = libc::ENOATTR;
 #[cfg(target_os = "linux")]

--- a/rufs/src/lib.rs
+++ b/rufs/src/lib.rs
@@ -10,10 +10,6 @@ mod ufs;
 #[cfg(feature = "icache")]
 const ICACHE_SIZE: usize = 1024;
 
-/// Number of blocks cached.
-#[cfg(feature = "bcache")]
-const BCACHE_SIZE: usize = 16;
-
 /// Number of directory entries to cache.
 #[cfg(feature = "dcache")]
 const DCACHE_SIZE: usize = 1024;

--- a/rufs/src/lib.rs
+++ b/rufs/src/lib.rs
@@ -12,6 +12,9 @@ const ICACHE_SIZE: usize = 1024;
 /// Number of blocks cached.
 const BCACHE_SIZE: usize = 16;
 
+/// Number of directory entries to cache.
+const DCACHE_SIZE: usize = 1024;
+
 #[cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "macos"))]
 pub const ENOATTR: i32 = libc::ENOATTR;
 #[cfg(target_os = "linux")]

--- a/rufs/src/ufs/dir.rs
+++ b/rufs/src/ufs/dir.rs
@@ -1,4 +1,7 @@
-use std::{io::{BufRead, Write}, path::Component};
+use std::{
+	io::{BufRead, Write},
+	path::Component,
+};
 
 use super::*;
 use crate::{err, InodeNum};
@@ -257,18 +260,19 @@ impl<R: Backend> Ufs<R> {
 		if let Some(cached) = self.dcache.get(&q) {
 			return Ok(*cached);
 		}
-		
-		let inr = self.dir_iter(
-			pinr,
-			|name2, inr, _kind| {
-				if name == name2 {
-					Some(inr)
-				} else {
-					None
-				}
-			},
-		)?
-		.ok_or(err!(ENOENT))?;
+
+		let inr = self
+			.dir_iter(
+				pinr,
+				|name2, inr, _kind| {
+					if name == name2 {
+						Some(inr)
+					} else {
+						None
+					}
+				},
+			)?
+			.ok_or(err!(ENOENT))?;
 
 		#[cfg(feature = "dcache")]
 		self.dcache.push(q, inr);
@@ -461,8 +465,8 @@ impl<R: Backend> Ufs<R> {
 			match c {
 				Component::Normal(name) => {
 					inr = self.dir_lookup(inr, name)?;
-				},
-				Component::CurDir => {},
+				}
+				Component::CurDir => {}
 				_ => {
 					log::error!("lookup({path:?}): invalid component: {c:?}");
 					return Err(err!(EINVAL));

--- a/rufs/src/ufs/dir.rs
+++ b/rufs/src/ufs/dir.rs
@@ -251,7 +251,9 @@ impl<R: Backend> Ufs<R> {
 	pub fn dir_lookup(&mut self, pinr: InodeNum, name: &OsStr) -> IoResult<InodeNum> {
 		log::trace!("dir_lookup({pinr}, {name:?});");
 
+		#[cfg(feature = "dcache")]
 		let q = (pinr, name.into());
+		#[cfg(feature = "dcache")]
 		if let Some(cached) = self.dcache.get(&q) {
 			return Ok(*cached);
 		}
@@ -267,6 +269,8 @@ impl<R: Backend> Ufs<R> {
 			},
 		)?
 		.ok_or(err!(ENOENT))?;
+
+		#[cfg(feature = "dcache")]
 		self.dcache.push(q, inr);
 
 		Ok(inr)
@@ -300,6 +304,7 @@ impl<R: Backend> Ufs<R> {
 		let mut dino = self.read_inode(dinr)?;
 		dino.assert_dir()?;
 
+		#[cfg(feature = "dcache")]
 		let _ = self.dcache.pop(&(dinr, name.into()));
 
 		let mut block = vec![0u8; DIRBLKSIZE];

--- a/rufs/src/ufs/dir.rs
+++ b/rufs/src/ufs/dir.rs
@@ -266,17 +266,17 @@ impl<R: Backend> Ufs<R> {
 	/// Iterate through a directory referenced by `inr`, and call `f` for each entry.
 	pub fn dir_iter<T>(
 		&mut self,
-		inr: InodeNum,
+		dinr: InodeNum,
 		mut f: impl FnMut(&OsStr, InodeNum, InodeType) -> Option<T>,
 	) -> IoResult<Option<T>> {
-		let ino = self.read_inode(inr)?;
-		ino.assert_dir()?;
+		let dino = self.read_inode(dinr)?;
+		dino.assert_dir()?;
 		let mut block = [0u8; DIRBLKSIZE];
 		let mut pos = 0;
-		while pos < ino.size {
-			let n = self.inode_read(inr, pos, &mut block)?;
+		while pos < dino.size {
+			let n = self.inode_do_read(dinr, &dino, pos, &mut block)?;
 			assert_eq!(n, DIRBLKSIZE);
-			if let Some(x) = readdir_block(inr, &block, self.file.config(), &mut f)? {
+			if let Some(x) = readdir_block(dinr, &block, self.file.config(), &mut f)? {
 				return Ok(Some(x));
 			}
 
@@ -288,18 +288,18 @@ impl<R: Backend> Ufs<R> {
 	pub(super) fn dir_unlink(&mut self, dinr: InodeNum, name: &OsStr) -> IoResult<InodeNum> {
 		log::trace!("dir_unlink({dinr}, {name:?});");
 		self.assert_rw()?;
-		let dino = self.read_inode(dinr)?;
+		let mut dino = self.read_inode(dinr)?;
 		dino.assert_dir()?;
 
 		let mut block = vec![0u8; DIRBLKSIZE];
 		let mut pos = 0;
 		while pos < dino.size {
-			let n = self.inode_read(dinr, pos, &mut block)?;
+			let n = self.inode_do_read(dinr, &dino, pos, &mut block)?;
 			assert_eq!(n, DIRBLKSIZE);
 
 			if let Some((inr, has)) = unlink_block(dinr, &mut block, name, self.file.config())? {
 				if has {
-					self.inode_write(dinr, pos, &block)?;
+					self.inode_do_write(dinr, &mut dino, pos, &block)?;
 				} else {
 					let n =
 						self.inode_copy_range(dinr, &dino, (pos + DIRBLKSIZE as u64).., pos..)?;
@@ -324,7 +324,7 @@ impl<R: Backend> Ufs<R> {
 	) -> IoResult<()> {
 		log::trace!("dir_newlink({dinr}, {inr}, {name:?}, {kind:?});");
 		self.assert_rw()?;
-		let dino = self.read_inode(dinr)?;
+		let mut dino = self.read_inode(dinr)?;
 		dino.assert_dir()?;
 
 		let mut entry = Header::new(inr, kind, name);
@@ -332,11 +332,11 @@ impl<R: Backend> Ufs<R> {
 		let mut block = [0u8; DIRBLKSIZE];
 		let mut pos = 0;
 		while pos < dino.size {
-			let n = self.inode_read(dinr, pos, &mut block)?;
+			let n = self.inode_do_read(dinr, &dino, pos, &mut block)?;
 			assert_eq!(n, DIRBLKSIZE);
 
 			if newlink_block(&mut block, entry, self.file.config())? {
-				self.inode_write(dinr, pos, &block)?;
+				self.inode_do_write(dinr, &mut dino, pos, &block)?;
 				return Ok(());
 			}
 
@@ -344,13 +344,14 @@ impl<R: Backend> Ufs<R> {
 		}
 
 		log::trace!("dir_link({dinr}, {inr}, {name:?}, {kind:?}): extending directory for new entry: {entry:?}");
-		self.inode_truncate(dinr, dino.size + DIRBLKSIZE as u64)?;
+		let new_size = dino.size + DIRBLKSIZE as u64;
+		self.inode_do_truncate(dinr, &mut dino, new_size)?;
 		entry.reclen = DIRBLKSIZE as u16;
 		entry.write(&mut Decoder::new(
 			Cursor::new(&mut block as &mut [u8]),
 			self.file.config(),
 		))?;
-		self.inode_write(dinr, pos, &block)?;
+		self.inode_do_write(dinr, &mut dino, pos, &block)?;
 		Ok(())
 	}
 
@@ -426,7 +427,7 @@ impl<R: Backend> Ufs<R> {
 
 		let block = newdir(dinr, inr, self.file.config())?;
 		self.inode_truncate(inr, block.len() as u64)?;
-		self.inode_write(inr, 0, &block)?;
+		self.inode_do_write(inr, &mut ino, 0, &block)?;
 
 		let ino = self.read_inode(inr)?;
 		Ok(ino.as_attr(inr))

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -171,6 +171,7 @@ impl<R: Backend> Ufs<R> {
 			return Ok(());
 		}
 
+		#[cfg(feature = "icache")]
 		let _ = self.icache.pop(&inr);
 
 		let sb = &self.superblock;

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -93,6 +93,20 @@ impl<R: Backend> Ufs<R> {
 		Ok(())
 	}
 
+	pub(super) fn read_pblock_ptr(&mut self, bno: u64, idx: usize) -> IoResult<Option<NonZeroU64>> {
+		if bno == 0 {
+			return Ok(None);
+		}
+		let bs = self.superblock.bsize as usize;
+		let pbp = bs / size_of::<u64>();
+
+		let mut buf = vec![0u64; pbp];
+		self.read_pblock(bno, &mut buf)?;
+		let bno = buf[idx];
+
+		Ok(NonZeroU64::new(bno))
+	}
+
 	pub(super) fn write_pblock(&mut self, bno: u64, block: &[u64]) -> IoResult<()> {
 		let fs = self.superblock.fsize as u64;
 		let bs = self.superblock.bsize as usize;

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -370,7 +370,13 @@ impl<R: Backend> Ufs<R> {
 		let mut ino = self.read_inode(inr)?;
 		self.inode_do_truncate(inr, &mut ino, new_size)
 	}
-	pub(super) fn inode_do_truncate(&mut self, inr: InodeNum, ino: &mut Inode, new_size: u64) -> IoResult<()> {
+
+	pub(super) fn inode_do_truncate(
+		&mut self,
+		inr: InodeNum,
+		ino: &mut Inode,
+		new_size: u64,
+	) -> IoResult<()> {
 		log::trace!("inode_truncate({inr}, {new_size});");
 		self.assert_rw()?;
 

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -353,14 +353,17 @@ impl<R: Backend> Ufs<R> {
 	}
 
 	pub fn inode_truncate(&mut self, inr: InodeNum, new_size: u64) -> IoResult<()> {
+		let mut ino = self.read_inode(inr)?;
+		self.inode_do_truncate(inr, &mut ino, new_size)
+	}
+	pub(super) fn inode_do_truncate(&mut self, inr: InodeNum, ino: &mut Inode, new_size: u64) -> IoResult<()> {
 		log::trace!("inode_truncate({inr}, {new_size});");
 		self.assert_rw()?;
 
-		let mut ino = self.read_inode(inr)?;
 		let old_size = ino.size;
 
 		if new_size < old_size {
-			self.inode_shrink(&mut ino, new_size)?;
+			self.inode_shrink(ino, new_size)?;
 		}
 
 		ino.size = new_size;

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -171,6 +171,8 @@ impl<R: Backend> Ufs<R> {
 			return Ok(());
 		}
 
+		let _ = self.icache.pop(&inr);
+
 		let sb = &self.superblock;
 
 		// clear the inode

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -388,7 +388,7 @@ impl<R: Backend> Ufs<R> {
 
 		ino.size = new_size;
 
-		self.write_inode(inr, &ino)?;
+		self.write_inode(inr, ino)?;
 
 		Ok(())
 	}

--- a/rufs/src/ufs/ialloc.rs
+++ b/rufs/src/ufs/ialloc.rs
@@ -97,12 +97,11 @@ impl<R: Backend> Ufs<R> {
 		if bno == 0 {
 			return Ok(None);
 		}
-		let bs = self.superblock.bsize as usize;
-		let pbp = bs / size_of::<u64>();
+		let fs = self.superblock.fsize as u64;
+		let su64 = size_of::<u64>() as u64;
 
-		let mut buf = vec![0u64; pbp];
-		self.read_pblock(bno, &mut buf)?;
-		let bno = buf[idx];
+		let addr = bno * fs + (idx as u64) * su64;
+		let bno: u64 = self.file.decode_at(addr)?;
 
 		Ok(NonZeroU64::new(bno))
 	}

--- a/rufs/src/ufs/inode.rs
+++ b/rufs/src/ufs/inode.rs
@@ -33,12 +33,12 @@ impl<R: Backend> Ufs<R> {
 		let end = offset + len;
 
 		while offset < end {
-			let block = self.inode_find_block(inr, &ino, offset);
+			let block = self.inode_find_block(inr, ino, offset);
 			let num = (block.size - block.off).min(end - offset);
 
 			self.inode_read_block(
 				inr,
-				&ino,
+				ino,
 				block.blkidx,
 				&mut blockbuf[0..(block.size as usize)],
 			)?;
@@ -70,20 +70,20 @@ impl<R: Backend> Ufs<R> {
 
 		let mut blockbuf = vec![0u8; self.superblock.bsize as usize];
 		ino.size = ino.size.max(offset + buffer.len() as u64);
-		self.write_inode(inr, &ino)?;
+		self.write_inode(inr, ino)?;
 
 		let mut boff = 0;
 		let len = (buffer.len() as u64).min(ino.size - offset);
 		let end = offset + len;
 
 		while offset < end {
-			let block = self.inode_find_block(inr, &ino, offset);
+			let block = self.inode_find_block(inr, ino, offset);
 			let num = (block.size - block.off).min(end - offset);
 
 			// TODO: remove this read, if writing a full block
 			self.inode_read_block(
 				inr,
-				&ino,
+				ino,
 				block.blkidx,
 				&mut blockbuf[0..(block.size as usize)],
 			)?;

--- a/rufs/src/ufs/inode.rs
+++ b/rufs/src/ufs/inode.rs
@@ -172,6 +172,7 @@ impl<R: Backend> Ufs<R> {
 	pub(super) fn read_inode(&mut self, inr: InodeNum) -> IoResult<Inode> {
 		log::trace!("read_inode({inr});");
 
+		#[cfg(feature = "icache")]
 		if let Some(ino) = self.icache.get(&inr) {
 			return Ok(ino.clone());
 		}
@@ -184,6 +185,7 @@ impl<R: Backend> Ufs<R> {
 			return Err(err!(EINVAL));
 		}
 
+		#[cfg(feature = "icache")]
 		self.icache.push(inr, ino.clone());
 
 		Ok(ino)
@@ -194,6 +196,7 @@ impl<R: Backend> Ufs<R> {
 		self.assert_rw()?;
 		let off = self.superblock.ino_to_fso(inr);
 		self.file.encode_at(off, &ino)?;
+		#[cfg(feature = "icache")]
 		self.icache.push(inr, ino.clone());
 		Ok(())
 	}

--- a/rufs/src/ufs/inode.rs
+++ b/rufs/src/ufs/inode.rs
@@ -153,6 +153,11 @@ impl<R: Backend> Ufs<R> {
 
 	pub(super) fn read_inode(&mut self, inr: InodeNum) -> IoResult<Inode> {
 		log::trace!("read_inode({inr});");
+
+		if let Some(ino) = self.icache.get(&inr) {
+			return Ok(ino.clone());
+		}
+		
 		let off = self.superblock.ino_to_fso(inr);
 		let ino: Inode = self.file.decode_at(off)?;
 
@@ -169,6 +174,7 @@ impl<R: Backend> Ufs<R> {
 		self.assert_rw()?;
 		let off = self.superblock.ino_to_fso(inr);
 		self.file.encode_at(off, &ino)?;
+		self.icache.put(inr, ino.clone());
 		Ok(())
 	}
 

--- a/rufs/src/ufs/inode.rs
+++ b/rufs/src/ufs/inode.rs
@@ -13,15 +13,11 @@ impl<R: Backend> Ufs<R> {
 	}
 
 	/// Read data from an inode.
-	pub fn inode_read(
-		&mut self,
-		inr: InodeNum,
-		offset: u64,
-		buffer: &mut [u8],
-	) -> IoResult<usize> {
+	pub fn inode_read(&mut self, inr: InodeNum, offset: u64, buffer: &mut [u8]) -> IoResult<usize> {
 		let ino = self.read_inode(inr)?;
 		self.inode_do_read(inr, &ino, offset, buffer)
 	}
+
 	pub(super) fn inode_do_read(
 		&mut self,
 		inr: InodeNum,
@@ -57,15 +53,11 @@ impl<R: Backend> Ufs<R> {
 		Ok(boff)
 	}
 
-	pub fn inode_write(
-		&mut self,
-		inr: InodeNum,
-		offset: u64,
-		buffer: &[u8],
-	) -> IoResult<usize> {
+	pub fn inode_write(&mut self, inr: InodeNum, offset: u64, buffer: &[u8]) -> IoResult<usize> {
 		let mut ino = self.read_inode(inr)?;
 		self.inode_do_write(inr, &mut ino, offset, buffer)
 	}
+
 	pub(super) fn inode_do_write(
 		&mut self,
 		inr: InodeNum,
@@ -100,12 +92,7 @@ impl<R: Backend> Ufs<R> {
 			blockbuf[off..(off + num as usize)]
 				.copy_from_slice(&buffer[boff..(boff + num as usize)]);
 
-			self.inode_write_block(
-				inr,
-				 ino,
-				block.blkidx,
-				&blockbuf[0..(block.size as usize)],
-			)?;
+			self.inode_write_block(inr, ino, block.blkidx, &blockbuf[0..(block.size as usize)])?;
 
 			offset += num;
 			boff += num as usize;
@@ -176,7 +163,7 @@ impl<R: Backend> Ufs<R> {
 		if let Some(ino) = self.icache.get(&inr) {
 			return Ok(ino.clone());
 		}
-		
+
 		let off = self.superblock.ino_to_fso(inr);
 		let ino: Inode = self.file.decode_at(off)?;
 

--- a/rufs/src/ufs/inode.rs
+++ b/rufs/src/ufs/inode.rs
@@ -166,6 +166,8 @@ impl<R: Backend> Ufs<R> {
 			return Err(err!(EINVAL));
 		}
 
+		self.icache.push(inr, ino.clone());
+
 		Ok(ino)
 	}
 
@@ -174,7 +176,7 @@ impl<R: Backend> Ufs<R> {
 		self.assert_rw()?;
 		let off = self.superblock.ino_to_fso(inr);
 		self.file.encode_at(off, &ino)?;
-		self.icache.put(inr, ino.clone());
+		self.icache.push(inr, ino.clone());
 		Ok(())
 	}
 

--- a/rufs/src/ufs/mod.rs
+++ b/rufs/src/ufs/mod.rs
@@ -64,7 +64,11 @@ pub struct Info {
 pub struct Ufs<R: Backend> {
 	file:       Decoder<BlockReader<R>>,
 	superblock: Superblock,
+	// inode cache
 	icache: LruCache<InodeNum, Inode>,
+
+	// directory name cache
+	dcache: LruCache<(InodeNum, OsString), InodeNum>,
 }
 
 impl Ufs<File> {
@@ -108,6 +112,7 @@ impl<R: Backend> Ufs<R> {
 			file,
 			superblock,
 			icache: LruCache::new(NonZeroUsize::new(crate::ICACHE_SIZE).unwrap()),
+			dcache: LruCache::new(NonZeroUsize::new(crate::DCACHE_SIZE).unwrap()),
 		};
 		s.check()?;
 		Ok(s)

--- a/rufs/src/ufs/symlink.rs
+++ b/rufs/src/ufs/symlink.rs
@@ -19,6 +19,7 @@ impl<R: Backend> Ufs<R> {
 			}
 			InodeData::Blocks { .. } => {
 				// TODO: this has to be tested for other configurations, such as 4K/4K
+				// TODO: use inode_do_read()
 				assert!(ino.blocks <= 8);
 
 				let len = ino.size as usize;


### PR DESCRIPTION
TODO:
- [x] Implement benchmarking
- [x] Inode LruCache (see [lru](https://docs.rs/lru)) (icache)
- [x] Directory Entry Cache (dcache)
- [ ] Cache the last accessed file block
- [x] Add a small block cache (bcache)
  - [ ] Optimize, or remove
- [x] Make caching optional
- [ ] Find other performance improvements
- [ ] Track write performance
- [ ] More benchmarks
- [x] speed up `inode_resolve_block()`

Original performance numbers (on a Ryzen 9 7900):
| Test | Variant              | Time    | Throughput  |
|------|----------------------|---------|-------------|
| open |                      | 20.2 us |             |
| read | 1MiB                 | 27.8 ms | 983 MiB/s   |
| read | 64KiB                | 28.7 ms | 955 MiB/s   |
| read | 16KiB                | 30.6 ms | 896 MiB/s   |
| read | 4KiB                 | 118 ms  | 232 MiB/s   |
| read | 512B                 | 934 ms  | 29 MiB/s    |
| find | direct               | 610 us  | 3.1 Mfile/s |
| find | lookup               | 1.77 ms | 1.1 Mfile/s |
| find | lookup+stat          | 109 ms  | 17 Kfile/s  |
| find | lookup+stat+read-64K | 193 ms  | 9.8 Kfile/s |
| find | lookup+stat+read-16K | 202 ms  | 9.3 Kfile/s |
| find | lookup+stat+read-4K  | 455 ms  | 4.2 Kfile/s |
| find | lookup+stat+read-512 | 2.9 s   | 652 file/s  |
