### PR TITLE
Switch CI from using "-Zminimal-versions" to "-Zdirect-minimal-versions"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,7 +44,7 @@ task:
   # Test our minimal version spec
   minver_test_script:
     - . $HOME/.cargo/env
-    - cargo update -Zminimal-versions
+    - cargo update -Zdirect-minimal-versions
     - cargo check --all-targets
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ daemonize = "0.5.0"
 env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime"] }
 fuse2rs = "0.1.2"
 fuser = "0.15.1"
-libc = "0.2.155"
+libc = "0.2.158"
 log = "0.4.22"
 rufs = { version = "0.5.0", path = "rufs" }
 


### PR DESCRIPTION
This is less likely to be broken by new changes in a dependency.