### PR TITLE
Eliminate the daemonize crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,12 +182,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -258,15 +252,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "daemonize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "defmt"
@@ -365,13 +350,12 @@ dependencies = [
  "cfg-if",
  "clap",
  "clap-verbosity-flag",
- "daemonize",
  "env_logger",
  "fuse2rs",
  "fuser",
  "libc",
  "log",
- "nix 0.28.0",
+ "nix",
  "rand 0.9.4",
  "rstest",
  "rstest_reuse",
@@ -400,7 +384,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.29.0",
+ "nix",
  "page_size",
  "pkg-config",
  "smallvec",
@@ -563,25 +547,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ bincode-next = "3.1.1"
 cfg-if = "1.0"
 clap = { version = "4.5.4", features = ["derive"] }
 clap-verbosity-flag = "2.2.1"
-daemonize = "0.5.0"
 env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime"] }
 fuse2rs = "0.1.2"
 # Technically the libfuse dependency is only needed on FreeBSD,
@@ -21,11 +20,11 @@ fuse2rs = "0.1.2"
 fuser = { version = "0.16.0", features = [ "libfuse" ] }
 libc = "0.2.176"
 log = "0.4.22"
+nix = "0.29.0"
 rufs = { version = "0.6.0", path = "rufs" }
 
 # Dev dependencies
 assert_cmd = "2.0"
-nix = { version = "0.28.0", features = ["fs", "dir"] }
 rstest = { version = "0.19.0", default-features = false }
 rstest_reuse = "0.7.0"
 tempfile = "3.0"

--- a/fuse-ufs/Cargo.toml
+++ b/fuse-ufs/Cargo.toml
@@ -24,18 +24,18 @@ anyhow.workspace = true
 cfg-if.workspace = true
 clap.workspace = true
 clap-verbosity-flag.workspace = true
-daemonize.workspace = true
 env_logger.workspace = true
 fuse2rs = { workspace = true, optional = true }
 fuser = { workspace = true, optional = true }
 libc.workspace = true
 log.workspace = true
+nix = { workspace = true, features = ["process"] }
 rufs.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true
 cfg-if.workspace = true
-nix = { workspace = true, features = ["fs", "dir"] }
+nix = { workspace = true, features = ["fs", "dir", "process"] }
 rand.workspace = true
 rstest = { workspace = true, default-features = false }
 rstest_reuse.workspace = true

--- a/fuse-ufs/src/main.rs
+++ b/fuse-ufs/src/main.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use anyhow::Result;
 use cfg_if::cfg_if;
 use clap::Parser;
+use nix::unistd::daemon;
 use rufs::Ufs;
 
 use crate::cli::Cli;
@@ -58,9 +59,7 @@ fn main() -> Result<()> {
 			if cli.foreground {
 				fuser::mount2(fs, mp, &opts)?;
 			} else {
-				daemonize::Daemonize::new()
-					.working_directory(std::env::current_dir()?)
-					.start()?;
+				daemon(false, false)?;
 				fuser::mount2(fs, mp, &opts)?;
 			}
 		} else if #[cfg(feature = "fuse2")] {


### PR DESCRIPTION
Because it's unmaintained.  Instead, use Nix's daemon() function.  Also, update Nix to 0.29.0, because fuser did.

The downside is that Nix does not make daemon available on OSX.

RUSTSEC-2025-0069
Fixes #102